### PR TITLE
feat: link to Inrupt.com signup

### DIFF
--- a/packages/solid-crs-manage/lib/i8n/nl-NL.json
+++ b/packages/solid-crs-manage/lib/i8n/nl-NL.json
@@ -87,7 +87,7 @@
     {
         "key": "nde.features.authenticate.pages.login.create-webid",
         "locale": "nl-NL",
-        "value": "Nog geen WebID? Klik <a href=\"https://pods.nde.nl\">hier</a>."
+        "value": "Nog geen WebID? Klik <a href=\"https://signup.pod.inrupt.com\">hier</a>."
     },
     {
         "key": "nde.features.collections.alerts.created-collection",


### PR DESCRIPTION
As discussed during today’s demo: while the app is agnostic as to the pod provider used, we will point to Inrupt.com for now because Solid CRS works out of the box with that provider.