### PR TITLE
fix: nde-erfgoed renames in docs

### DIFF
--- a/docs/modules/manual/pages/install.adoc
+++ b/docs/modules/manual/pages/install.adoc
@@ -40,11 +40,11 @@ Alternatively, you can build and run an image locally.
 
 [source,bash]
 ----
-# Build on Mac
-$ docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t crs:local ./packages/nde-erfgoed-manage/
+# Build on Linux/Mac
+$ docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t crs:local ./packages/solid-crs-manage/
 
 # Build on Windows
-$ docker build --build-arg NPM_TOKEN=%NPM_TOKEN% -t crs:local ./packages/nde-erfgoed-manage/
+$ docker build --build-arg NPM_TOKEN=%NPM_TOKEN% -t crs:local ./packages/solid-crs-manage/
 
 # Run local image
 $ docker run -p 3002:3002 crs:local

--- a/docs/modules/specs/pages/add-svg-icons.adoc
+++ b/docs/modules/specs/pages/add-svg-icons.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=682525025[Wrike task]
 * Branch: `feat/add-svg-icons`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-components]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-components]
 
 
 == Introduction
@@ -60,9 +60,9 @@ I suggest the following names:
 * Logout (already exists)
 * Loading (already exists, change svg)
 
-Loading's exising svg should be replaced with the new icon. Ideally, it should turn clockwise in increments of 15%. I'm not sure how this is best done. The styling and animation of this icon should happen in the 'nde-erfgoed-theme' package, be it in the svg itself or, if necessary, in a new 'icons.css' file under 'lib/elements/'.
+Loading's exising svg should be replaced with the new icon. Ideally, it should turn clockwise in increments of 15%. I'm not sure how this is best done. The styling and animation of this icon should happen in the 'solid-crs-theme' package, be it in the svg itself or, if necessary, in a new 'icons.css' file under 'lib/elements/'.
 
-Export the icons from https://www.figma.com/file/K91OgRUlaDf6fhd95Rjgrg/NDE---CBS?node-id=1%3A3[these Figma assets] to svg files in 'nde-erfgoed-theme'. Test them out in 'nde-erfgoed-components' to make sure they render properly. The https://www.figma.com/file/K91OgRUlaDf6fhd95Rjgrg/NDE---CBS?node-id=361%3A375[image from the empty collection page] should also be exported and kept in 'nde-erfgoed-theme'.
+Export the icons from https://www.figma.com/file/K91OgRUlaDf6fhd95Rjgrg/NDE---CBS?node-id=1%3A3[these Figma assets] to svg files in 'solid-crs-theme'. Test them out in 'solid-crs-components' to make sure they render properly. The https://www.figma.com/file/K91OgRUlaDf6fhd95Rjgrg/NDE---CBS?node-id=361%3A375[image from the empty collection page] should also be exported and kept in 'solid-crs-theme'.
 
 The exported svgs come with a default `fill`, `height` and `width` attributes, e.g.: 
 

--- a/docs/modules/specs/pages/create-authenticate-login-page.adoc
+++ b/docs/modules/specs/pages/create-authenticate-login-page.adoc
@@ -13,7 +13,7 @@
 * https://www.wrike.com/open.htm?id=675145293[Wrike task]
 * https://docs.google.com/spreadsheets/d/1onOY60hXmEPQYN_nM6CK0uRYIHq7hPtYsE8pWaVe7es/edit#gid=1865680815[Test plan]
 * Branch: `feat/675145293-create-authentication-login-page`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-manage, nde-erfgoed-components]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-manage, solid-crs-components]
 
 
 == Introduction
@@ -43,7 +43,7 @@ All components and services are to be made in the '@netwerk-digitaal-erfgoed/sol
 
 All new components should be exported in 'lib/index.ts'.
 
-In 'nde-erfgoed-manage', register their HTML tags in app.ts. 
+In 'solid-crs-manage', register their HTML tags in app.ts. 
 
 
 ===== ButtonComponent 

--- a/docs/modules/specs/pages/create-collection-overview-page.adoc
+++ b/docs/modules/specs/pages/create-collection-overview-page.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=682525025[Wrike task]
 * Branch: `feat/create-content-header-component`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-components]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-components]
 
 
 == Introduction

--- a/docs/modules/specs/pages/create-content-header-component.adoc
+++ b/docs/modules/specs/pages/create-content-header-component.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=682525025[Wrike task]
 * Branch: `feat/create-content-header-component`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-components]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-components]
 
 
 == Introduction

--- a/docs/modules/specs/pages/create-object-card-component.adoc
+++ b/docs/modules/specs/pages/create-object-card-component.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=684057264[Wrike task]
 * Branch: `feat/create-object-card-component`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-components]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-components]
 
 
 == Introduction
@@ -33,7 +33,7 @@ All components are to be made in the '@netwerk-digitaal-erfgoed/solid-crs-compon
 
 ==== Collection model
 
-Edit 'collection.ts' under 'lib/collections/' in the 'nde-erfgoed-core' package.
+Edit 'collection.ts' under 'lib/collections/' in the 'solid-crs-core' package.
 
 [source, ts]
 ----
@@ -47,7 +47,7 @@ Edit 'collection.ts' under 'lib/collections/' in the 'nde-erfgoed-core' package.
 
 ==== CollectionObject model
 
-Create 'collection-object.ts' under 'lib/collections/' in the 'nde-erfgoed-core' package.
+Create 'collection-object.ts' under 'lib/collections/' in the 'solid-crs-core' package.
 
 [source, ts]
 ----
@@ -76,4 +76,4 @@ Hovering over the component should change the cursor as if the component is clic
 
 Export the component in 'lib/index.ts'.
 
-To preview the component while developing: register the component in 'lib/demo.ts', then add the component's tag to the 'index.html' file in the 'lib' directory. Running `npm run start:watch` in the 'nde-erfgoed-components' package will serve the 'index.html' file you just edited.
+To preview the component while developing: register the component in 'lib/demo.ts', then add the component's tag to the 'index.html' file in the 'lib' directory. Running `npm run start:watch` in the 'solid-crs-components' package will serve the 'index.html' file you just edited.

--- a/docs/modules/specs/pages/create-sidebar-list-item-component.adoc
+++ b/docs/modules/specs/pages/create-sidebar-list-item-component.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=682525025[Wrike task]
 * Branch: `feat/create-content-header-component`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-components]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-components]
 
 
 == Introduction
@@ -44,7 +44,7 @@ Make use of https://lit-element.readthedocs.io/en/v0.6.4/docs/templates/slots/#s
 
 Export the component in 'lib/index.ts'.
 
-To preview the component while developing: register the component in 'lib/demo.ts', then add the component's tag to the 'index.html' file in the 'lib' directory. Running `npm run start:watch` in the 'nde-erfgoed-components' package will serve the 'index.html' file you just edited.
+To preview the component while developing: register the component in 'lib/demo.ts', then add the component's tag to the 'index.html' file in the 'lib' directory. Running `npm run start:watch` in the 'solid-crs-components' package will serve the 'index.html' file you just edited.
 
 
 
@@ -61,4 +61,4 @@ The purpose of this component is to keep track of the currently selected list it
 
 Export the component in 'lib/index.ts'.
 
-To preview the component while developing: register the component in 'lib/demo.ts', then add the component's tag to the 'index.html' file in the 'lib' directory (add it to the existing sidebar). Running `npm run start:watch` in the 'nde-erfgoed-components' package will serve the 'index.html' file you just edited.
+To preview the component while developing: register the component in 'lib/demo.ts', then add the component's tag to the 'index.html' file in the 'lib' directory (add it to the existing sidebar). Running `npm run start:watch` in the 'solid-crs-components' package will serve the 'index.html' file you just edited.

--- a/docs/modules/specs/pages/create-solid-store.adoc
+++ b/docs/modules/specs/pages/create-solid-store.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=684597956[Wrike task]
 * Branch: `feat/create-solid-store`
-* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-manage]
+* Projects: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-manage]
 
 
 == Introduction

--- a/docs/modules/specs/pages/set-up-authenticate-feature.adoc
+++ b/docs/modules/specs/pages/set-up-authenticate-feature.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=674718417[Wrike task]
 * Branch: `feat/599439372-set-up-authenticate-feature`
-* Project: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-manage]
+* Project: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-manage]
 
 == Introduction
 
@@ -84,7 +84,7 @@ The initial value of `session` should be `new Session()`.
 
 Create following events in 'lib/features/authenticate/authenticate.events.ts'
 
-Take a look at https://github.com/netwerk-digitaal-erfgoed/solid-crs/blob/develop/packages/nde-erfgoed-manage/lib/features/collections/collections.events.ts[collections.events.ts] and https://github.com/netwerk-digitaal-erfgoed/solid-crs/blob/develop/packages/nde-erfgoed-manage/lib/features/collections/collections.actions.ts[collections.actions.ts].
+Take a look at https://github.com/netwerk-digitaal-erfgoed/solid-crs/blob/develop/packages/solid-crs-manage/lib/features/collections/collections.events.ts[collections.events.ts] and https://github.com/netwerk-digitaal-erfgoed/solid-crs/blob/develop/packages/solid-crs-manage/lib/features/collections/collections.actions.ts[collections.actions.ts].
 
 [options="header"]
 |======================================

--- a/docs/modules/specs/pages/set-up-collection-feature.adoc
+++ b/docs/modules/specs/pages/set-up-collection-feature.adoc
@@ -12,7 +12,7 @@
 
 * https://www.wrike.com/open.htm?id=684057269[Wrike task]
 * Branch: `feat/599439372-set-up-collection-feature`
-* Project: https://github.com/netwerk-digitaal-erfgoed/solid-crs[nde-erfgoed-manage]
+* Project: https://github.com/netwerk-digitaal-erfgoed/solid-crs[solid-crs-manage]
 
 == Introduction
 


### PR DESCRIPTION
Follow-up on e5ae4146797c9634f7add0fea4ef23b1a23b21f3