### PR TITLE
chore: add build script to id-proxy

### DIFF
--- a/packages/solid-crs-id-proxy/package-lock.json
+++ b/packages/solid-crs-id-proxy/package-lock.json
@@ -3067,6 +3067,12 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"interpret": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+			"dev": true
+		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -5076,6 +5082,15 @@
 				"readable-stream": "^3.6.0"
 			}
 		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5536,12 +5551,33 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
 		},
+		"shelljs": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true,
 			"optional": true
+		},
+		"shx": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/shx/-/shx-0.3.3.tgz",
+			"integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.3",
+				"shelljs": "^0.8.4"
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.6",

--- a/packages/solid-crs-id-proxy/package.json
+++ b/packages/solid-crs-id-proxy/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "dgt-id-proxy",
     "start:watch": "npm run start -- -u http://localhost:3003/ -U https://nde.eu.auth0.com/ -m . -c config/local-config.json -o assets/openid-configuration.json -j assets/jwks.json",
+    "build": "shx rm -rf assets && shx mkdir assets && npm run generate:oidc && npm run generate:keys",
     "lint:staged": "lint-staged",
     "generate:oidc": "node scripts/generate-openid-configuration.js https://nde.eu.auth0.com/ http://localhost:3003/ assets/openid-configuration.json local",
     "generate:keys": "node scripts/generate-keys.js assets/jwks.json"
@@ -40,7 +41,7 @@
     "jest": "^26.6.3",
     "jest-coverage-thresholds-bumper": "0.0.4",
     "lint-staged": "^10.5.4",
-    "rimraf": "^3.0.2",
+    "shx": "^0.3.3",
     "ts-jest": "^26.5.4",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"


### PR DESCRIPTION
`npm run build` creates fresh assets directory, then runs the generate scripts.

Otherwise following the install guide errors with 'file not found' when starting id-proxy.

@woutermont @AbelVandenBriel wdyt? 
