### PR TITLE
feat: improved copy url in presentation

### DIFF
--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
@@ -296,6 +296,28 @@ describe('ObjectRootComponent', () => {
 
   });
 
+  it('should copy value to clipboard when onClickedCopy is fired', async () => {
+
+    (navigator.clipboard as any) = {
+      writeText: jest.fn(async() => undefined),
+    };
+
+    machine.parent.onEvent((event) => {
+
+      if (event.type === AppEvents.ADD_ALERT) {
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+
+      }
+
+    });
+
+    window.document.body.appendChild(component);
+    await component.updateComplete;
+    component.onClickedCopy('test');
+
+  });
+
   it('should send SelectedCollectionEvent to parent when collection is clicked', async () => {
 
     machine.start();

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
@@ -274,7 +274,7 @@ describe('ObjectRootComponent', () => {
 
   it('should call onClickedCopy when copy image url is clicked', async () => {
 
-    component.onClickedCopy = jest.fn();
+    component.onClickedCopy = jest.fn().mockResolvedValueOnce(void 0);
     window.document.body.appendChild(component);
     await component.updateComplete;
 

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
@@ -2,6 +2,7 @@ import { Alert, LargeCardComponent } from '@netwerk-digitaal-erfgoed/solid-crs-c
 import { ArgumentError, CollectionObjectMemoryStore, Collection, CollectionObject, CollectionMemoryStore, ConsoleLogger, LoggerLevel, SolidMockService, MockTranslator } from '@netwerk-digitaal-erfgoed/solid-crs-core';
 import { ObjectImageryComponent } from '@netwerk-digitaal-erfgoed/solid-crs-semcom-components';
 import { interpret, Interpreter } from 'xstate';
+import * as solidCrsClient from '@netwerk-digitaal-erfgoed/solid-crs-client';
 import { AppEvents, DismissAlertEvent } from '../../app.events';
 import { appMachine } from '../../app.machine';
 import { SelectedCollectionEvent } from '../collection/collection.events';
@@ -280,6 +281,17 @@ describe('ObjectRootComponent', () => {
     const copy = window.document.body.getElementsByTagName('nde-object-root')[0].shadowRoot.querySelector<HTMLElement>('.copy-image-url a');
     copy.click();
     expect(component.onClickedCopy).toHaveBeenCalledTimes(1);
+
+  });
+
+  it('should run the appropriate code when download-rdf a is clicked', async () => {
+
+    const spy = jest.spyOn(solidCrsClient, 'fetch');
+    window.document.body.appendChild(component);
+    await component.updateComplete;
+    const rdf = window.document.body.getElementsByTagName('nde-object-root')[0].shadowRoot.querySelector<HTMLElement>('.download-rdf');
+    rdf.click();
+    expect(spy).toHaveBeenCalled();
 
   });
 

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
@@ -278,7 +278,6 @@ describe('ObjectRootComponent', () => {
     await component.updateComplete;
 
     const copy = window.document.body.getElementsByTagName('nde-object-root')[0].shadowRoot.querySelector<HTMLElement>('.copy-image-url a');
-    console.log(copy);
     copy.click();
     expect(component.onClickedCopy).toHaveBeenCalledTimes(1);
 

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.spec.ts
@@ -271,6 +271,19 @@ describe('ObjectRootComponent', () => {
 
   });
 
+  it('should call onClickedCopy when copy image url is clicked', async () => {
+
+    component.onClickedCopy = jest.fn();
+    window.document.body.appendChild(component);
+    await component.updateComplete;
+
+    const copy = window.document.body.getElementsByTagName('nde-object-root')[0].shadowRoot.querySelector<HTMLElement>('.copy-image-url a');
+    console.log(copy);
+    copy.click();
+    expect(component.onClickedCopy).toHaveBeenCalledTimes(1);
+
+  });
+
   it('should copy url to clipboard when info menu item is clicked', async () => {
 
     (navigator.clipboard as any) = {

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
@@ -178,7 +178,7 @@ export class ObjectRootComponent extends RxLitElement {
           ${ unsafeSVG(Dots) }
           <nde-popup id="info-popup">
             <div slot="content">
-              <a @click="${downloadRDF}">
+              <a @click="${downloadRDF}" class="download-rdf">
                 ${this.translator.translate('object.root.menu.view-rdf')}
               </a>
               <a @click="${() => this.onClickedCopy(this.object?.uri)}">

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
@@ -122,10 +122,9 @@ export class ObjectRootComponent extends RxLitElement {
 
   }
 
-  onClickedCopy(value: string): void {
+  onClickedCopy(value: string): Promise<void> {
 
-    navigator.clipboard.writeText(value).then(() =>
-      this.actor.parent.send(new AddAlertEvent({ type: 'success', message: 'common.copied-url' })));
+    return navigator.clipboard.writeText(value);
 
   }
 
@@ -181,8 +180,8 @@ export class ObjectRootComponent extends RxLitElement {
               <a @click="${downloadRDF}" class="download-rdf">
                 ${this.translator.translate('object.root.menu.view-rdf')}
               </a>
-              <a @click="${() => this.onClickedCopy(this.object?.uri)}">
-                ${this.translator.translate('object.root.menu.copy-url')}
+              <a @click="${() => this.onClickedCopy(this.object?.uri).then(() => this.actor.parent.send(new AddAlertEvent({ type: 'success', message: 'common.copied-uri' })))}">
+                ${this.translator.translate('object.root.menu.copy-uri')}
               </a>
             </div>
           </nde-popup>
@@ -214,7 +213,7 @@ export class ObjectRootComponent extends RxLitElement {
           <div class="object-property">
             <div> ${ this.translator.translate('object.card.image.field.image-source') } </div>
             <div class="copy-image-url">
-              <a target="_blank" rel="noopener noreferrer" @click="${ () => this.onClickedCopy(this.object?.image)}">
+              <a target="_blank" rel="noopener noreferrer" @click="${ () => this.onClickedCopy(this.object?.image).then(() => this.actor.parent.send(new AddAlertEvent({ type: 'success', message: 'common.copied-url' })))}">
               ${ this.translator.translate('object.root.menu.copy-url') }
               </a>
             </div>

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
@@ -213,7 +213,7 @@ export class ObjectRootComponent extends RxLitElement {
           </div>
           <div class="object-property">
             <div> ${ this.translator.translate('object.card.image.field.image-source') } </div>
-            <div>
+            <div class="copy-image-url">
               <a target="_blank" rel="noopener noreferrer" @click="${ () => this.onClickedCopy(this.object?.image)}">
               ${ this.translator.translate('object.root.menu.copy-url') }
               </a>

--- a/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
+++ b/packages/solid-crs-presentation/lib/features/object/object-root.component.ts
@@ -122,6 +122,13 @@ export class ObjectRootComponent extends RxLitElement {
 
   }
 
+  onClickedCopy(value: string): void {
+
+    navigator.clipboard.writeText(value).then(() =>
+      this.actor.parent.send(new AddAlertEvent({ type: 'success', message: 'common.copied-url' })));
+
+  }
+
   /**
    * Renders the component as HTML.
    *
@@ -174,6 +181,9 @@ export class ObjectRootComponent extends RxLitElement {
               <a @click="${downloadRDF}">
                 ${this.translator.translate('object.root.menu.view-rdf')}
               </a>
+              <a @click="${() => this.onClickedCopy(this.object?.uri)}">
+                ${this.translator.translate('object.root.menu.copy-url')}
+              </a>
             </div>
           </nde-popup>
         </div>
@@ -204,8 +214,7 @@ export class ObjectRootComponent extends RxLitElement {
           <div class="object-property">
             <div> ${ this.translator.translate('object.card.image.field.image-source') } </div>
             <div>
-              <a target="_blank" rel="noopener noreferrer" @click="${ () => navigator.clipboard.writeText(this.object?.image)
-    .then(() => this.actor.parent.send(new AddAlertEvent({ type: 'success', message: 'common.copied-image-url' })))}">
+              <a target="_blank" rel="noopener noreferrer" @click="${ () => this.onClickedCopy(this.object?.image)}">
               ${ this.translator.translate('object.root.menu.copy-url') }
               </a>
             </div>
@@ -381,6 +390,7 @@ export class ObjectRootComponent extends RxLitElement {
           width: 100%;
         }
         #info-popup {
+          z-index: 110;
           height: auto;
           width: auto;
           position: absolute;

--- a/packages/solid-crs-presentation/lib/public/nl-NL.json
+++ b/packages/solid-crs-presentation/lib/public/nl-NL.json
@@ -182,7 +182,7 @@
             "KGM": "kg",
             "GRM": "g"
         },
-        "copied-image-url": "De URL van de afbeelding werd gekopieerd.",
+        "copied-url": "De URL werd gekopieerd.",
         "paginator": {
             "page-counter": "Pagina {CURRENT} van {TOTAL}"
         }

--- a/packages/solid-crs-presentation/lib/public/nl-NL.json
+++ b/packages/solid-crs-presentation/lib/public/nl-NL.json
@@ -53,6 +53,7 @@
             },
             "menu": {
                 "view-rdf": "RDF bekijken",
+                "copy-uri": "URI kopiëren",
                 "copy-url": "URL kopiëren"
             }
         },
@@ -183,6 +184,7 @@
             "GRM": "g"
         },
         "copied-url": "De URL werd gekopieerd.",
+        "copied-uri": "De URI werd gekopieerd.",
         "paginator": {
             "page-counter": "Pagina {CURRENT} van {TOTAL}"
         }

--- a/packages/solid-crs-presentation/package.json
+++ b/packages/solid-crs-presentation/package.json
@@ -88,10 +88,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 87.37,
+        "statements": 87.4,
         "branches": 82.97,
-        "lines": 88.77,
-        "functions": 74.03
+        "lines": 88.74,
+        "functions": 74.16
       }
     },
     "automock": false,

--- a/packages/solid-crs-presentation/package.json
+++ b/packages/solid-crs-presentation/package.json
@@ -91,7 +91,7 @@
         "statements": 86.93,
         "branches": 82.97,
         "lines": 88.29,
-        "functions": 72.91
+        "functions": 72.81
       }
     },
     "automock": false,

--- a/packages/solid-crs-presentation/package.json
+++ b/packages/solid-crs-presentation/package.json
@@ -88,10 +88,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 86.93,
+        "statements": 87.15,
         "branches": 82.97,
-        "lines": 88.29,
-        "functions": 72.81
+        "lines": 88.53,
+        "functions": 73.42
       }
     },
     "automock": false,

--- a/packages/solid-crs-presentation/package.json
+++ b/packages/solid-crs-presentation/package.json
@@ -88,10 +88,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 86.93,
+        "statements": 87.37,
         "branches": 82.97,
-        "lines": 88.29,
-        "functions": 72.81
+        "lines": 88.77,
+        "functions": 74.03
       }
     },
     "automock": false,

--- a/packages/solid-crs-presentation/package.json
+++ b/packages/solid-crs-presentation/package.json
@@ -88,10 +88,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 87.15,
+        "statements": 86.93,
         "branches": 82.97,
-        "lines": 88.53,
-        "functions": 73.42
+        "lines": 88.29,
+        "functions": 72.91
       }
     },
     "automock": false,


### PR DESCRIPTION
- [x] extract to new function `onClickedCopy(value: string)`, which copies `value` to clipboard.
- [x] replace old @click arrow function with new `onClickedCopy` function
- [x] write tests for this function
- [x] add copy button to the top right menu in presentation
- [x] use new `onClickedCopy` for copying object URI