### PR TITLE
fix: invalid/unused env variables

### DIFF
--- a/packages/solid-crs-manage/.env.development
+++ b/packages/solid-crs-manage/.env.development
@@ -2,4 +2,3 @@ VITE_CLIENT_ID_URI=https://sandbox.webid.netwerkdigitaalerfgoed.nl/.well-known/o
 VITE_SEMCOM_NODE_URI=http://localhost:3003
 VITE_TERM_ENDPOINT=https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql
 VITE_PRESENTATION_URI=http://localhost:3005/
-VITE_PODS_URI=http://localhost:3000/

--- a/packages/solid-crs-manage/.env.production
+++ b/packages/solid-crs-manage/.env.production
@@ -2,4 +2,3 @@ VITE_CLIENT_ID_URI=https://webid.netwerkdigitaalerfgoed.nl/.well-known/oauth-cli
 VITE_SEMCOM_NODE_URI=https://solid-crs.netwerkdigitaalerfgoed.nl/semcom
 VITE_TERM_ENDPOINT=https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql
 VITE_PRESENTATION_URI=https://solid-crs-presentatie.netwerkdigitaalerfgoed.nl/
-VITE_PODS_URI=https://pods.netwerkdigitaalerfgoed.nl/

--- a/packages/solid-crs-manage/.env.production
+++ b/packages/solid-crs-manage/.env.production
@@ -1,5 +1,5 @@
 VITE_CLIENT_ID_URI=https://webid.netwerkdigitaalerfgoed.nl/.well-known/oauth-client
-ITE_SEMCOM_NODE_URI=https://solid-crs.netwerkdigitaalerfgoed.nl/semcom
+VITE_SEMCOM_NODE_URI=https://solid-crs.netwerkdigitaalerfgoed.nl/semcom
 VITE_TERM_ENDPOINT=https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql
 VITE_PRESENTATION_URI=https://solid-crs-presentatie.netwerkdigitaalerfgoed.nl/
 VITE_PODS_URI=https://pods.netwerkdigitaalerfgoed.nl/

--- a/packages/solid-crs-manage/.env.production-actual
+++ b/packages/solid-crs-manage/.env.production-actual
@@ -1,3 +1,4 @@
 VITE_CLIENT_ID_URI=https://webid.netwerkdigitaalerfgoed.nl/.well-known/oauth-client
 VITE_SEMCOM_NODE_URI=https://solid-crs.netwerkdigitaalerfgoed.nl/semcom
 VITE_TERM_ENDPOINT=https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql
+VITE_PRESENTATION_URI=https://solid-crs-presentatie.netwerkdigitaalerfgoed.nl/

--- a/packages/solid-crs-manage/lib/app-root.component.ts
+++ b/packages/solid-crs-manage/lib/app-root.component.ts
@@ -98,7 +98,7 @@ export class AppRootComponent extends RxLitElement {
   constructor(
     private solidService = new SolidSDKService({
       clientName: 'Collectiebeheersysteem',
-      clientId: `https://webid.netwerkdigitaalerfgoed.nl/.well-known/oauth-client`,
+      clientId: process.env.VITE_CLIENT_ID_URI,
     }),
   ) {
 

--- a/packages/solid-crs-presentation/.env.development
+++ b/packages/solid-crs-presentation/.env.development
@@ -1,2 +1,1 @@
 VITE_SEMCOM_NODE_URI=http://localhost:3003
-VITE_TERM_ENDPOINT=https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql

--- a/packages/solid-crs-presentation/.env.production
+++ b/packages/solid-crs-presentation/.env.production
@@ -1,2 +1,1 @@
 VITE_SEMCOM_NODE_URI=https://solid-crs.netwerkdigitaalerfgoed.nl/semcom
-VITE_TERM_ENDPOINT=https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql

--- a/packages/solid-crs-presentation/lib/app-root.component.ts
+++ b/packages/solid-crs-presentation/lib/app-root.component.ts
@@ -103,7 +103,7 @@ export class AppRootComponent extends RxLitElement {
    */
   private solidService = new SolidSDKService({
     clientName: 'Collectiebeheersysteem',
-    clientId: `https://webid.netwerkdigitaalerfgoed.nl/.well-known/oauth-client`,
+    clientId: process.env.VITE_CLIENT_ID_URI,
   });
 
   async connectedCallback(): Promise<void> {


### PR DESCRIPTION
Fixed typo in manage .env.production: `ITE_SEMCOM_NODE_URI` -> `VITE_SEMCOM_NODE_URI`

Also removed unused variables + removed hardcoded value for `VITE_CLIENT_ID_URI`